### PR TITLE
Bump to 2.4.0 — SDK 0.4.49, new Sandbox docs, Orchestration rename

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Tensorlake SDK for agent sandboxes and sandbox-native orchestration. Use when building AI agents that need sandboxed execution environments, isolated tool calls, or durable workflow orchestration.",
   "author": "TensorLake",
   "homepage": "https://github.com/tensorlakeai/tensorlake-skills",

--- a/.github/scripts/sources.yaml
+++ b/.github/scripts/sources.yaml
@@ -9,22 +9,26 @@
 sandbox_sdk.md:
   sources:
     - https://docs.tensorlake.ai/sandboxes/introduction.md
+    - https://docs.tensorlake.ai/sandboxes/quickstart.md
+    - https://docs.tensorlake.ai/sandboxes/concepts.md
     - https://docs.tensorlake.ai/sandboxes/commands.md
+    - https://docs.tensorlake.ai/sandboxes/environment-variables.md
     - https://docs.tensorlake.ai/sandboxes/file-operations.md
     - https://docs.tensorlake.ai/sandboxes/processes.md
     - https://docs.tensorlake.ai/sandboxes/networking.md
     - https://docs.tensorlake.ai/sandboxes/images.md
     - https://docs.tensorlake.ai/sandboxes/pty-sessions.md
     - https://docs.tensorlake.ai/sandboxes/computer-use.md
-  sdk_version: "0.4.44"
-  last_verified: "2026-04-10"
+    - https://docs.tensorlake.ai/sandboxes/docker.md
+  sdk_version: "0.4.49"
+  last_verified: "2026-04-22"
 
 sandbox_persistence.md:
   sources:
     - https://docs.tensorlake.ai/sandboxes/lifecycle.md
     - https://docs.tensorlake.ai/sandboxes/snapshots.md
-  sdk_version: "0.4.44"
-  last_verified: "2026-04-10"
+  sdk_version: "0.4.49"
+  last_verified: "2026-04-22"
 
 applications_sdk.md:
   sources:
@@ -51,9 +55,8 @@ applications_sdk.md:
     - https://docs.tensorlake.ai/applications/sandboxes.md
     - https://docs.tensorlake.ai/applications/guides/streaming-progress.md
     - https://docs.tensorlake.ai/applications/guides/logging.md
-    - https://docs.tensorlake.ai/applications/guides/autoscaling.md
-  sdk_version: "0.4.39"
-  last_verified: "2026-04-07"
+  sdk_version: "0.4.49"
+  last_verified: "2026-04-22"
 
 documentai_sdk.md:
   sources:
@@ -76,8 +79,8 @@ documentai_sdk.md:
     - https://docs.tensorlake.ai/document-ingestion/datasets/data.md
     - https://docs.tensorlake.ai/document-ingestion/file-management/overview.md
     - https://docs.tensorlake.ai/document-ingestion/parsing/on-prem.md
-  sdk_version: "0.4.39"
-  last_verified: "2026-04-07"
+  sdk_version: "0.4.49"
+  last_verified: "2026-04-22"
 
 integrations.md:
   sources:
@@ -87,8 +90,8 @@ integrations.md:
     - https://docs.tensorlake.ai/integrations/qdrant.md
     - https://docs.tensorlake.ai/integrations/databricks.md
     - https://docs.tensorlake.ai/integrations/motherduck.md
-  sdk_version: "0.4.39"
-  last_verified: "2026-04-07"
+  sdk_version: "0.4.49"
+  last_verified: "2026-04-22"
 
 platform.md:
   sources:
@@ -106,8 +109,8 @@ platform.md:
     - https://docs.tensorlake.ai/platform/playground/sample-documents.md
     - https://docs.tensorlake.ai/platform/security.md
     - https://docs.tensorlake.ai/platform/sso.md
-  sdk_version: "0.4.39"
-  last_verified: "2026-04-07"
+  sdk_version: "0.4.49"
+  last_verified: "2026-04-22"
 
 sandbox_advanced.md:
   sources:
@@ -119,8 +122,8 @@ sandbox_advanced.md:
     - https://docs.tensorlake.ai/sandboxes/agentic-rl-reproducible-env.md
     - https://docs.tensorlake.ai/sandboxes/agentic-swarm-intelligence.md
     - https://docs.tensorlake.ai/sandboxes/gspo-agentic-rl.md
-  sdk_version: "0.4.39"
-  last_verified: "2026-04-07"
+  sdk_version: "0.4.49"
+  last_verified: "2026-04-22"
 
 troubleshooting.md:
   sources:
@@ -128,5 +131,5 @@ troubleshooting.md:
     - https://docs.tensorlake.ai/applications/production/troubleshooting.md
     - https://docs.tensorlake.ai/document-ingestion/production/integration.md
     - https://docs.tensorlake.ai/document-ingestion/production/benchmarks.md
-  sdk_version: "0.4.39"
-  last_verified: "2026-04-07"
+  sdk_version: "0.4.49"
+  last_verified: "2026-04-22"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
 # Tensorlake SDK
-<!-- version: 2.3.1 -->
+<!-- version: 2.4.0 -->
 
 Tensorlake provides two APIs for building agentic applications:
 
 - **Sandbox** — Stateful execution environments for agents and isolated tool calls, with suspend/resume, snapshots, and clone for persistence between tasks
-- **Orchestrate** — Sandbox-native durable workflow orchestration for agents, with parallel map/reduce, auto-scaling, and crash recovery (imported as `tensorlake.applications`)
+- **Orchestration** — Sandbox-native durable workflow orchestration for agents, with parallel map/reduce, auto-scaling, and crash recovery (imported as `tensorlake.applications`)
 
 Available in both **Python** (`pip install tensorlake`) and **TypeScript** (`npm install tensorlake`). Use standalone or as infrastructure alongside any LLM provider, agent framework, database, or API.
 
@@ -70,7 +70,7 @@ if __name__ == "__main__":
 ## Core Patterns
 
 - **DAG composition**: Chain functions via `.future()`, `.map()`, `.reduce()` to form parallel pipelines
-- **Agentic + Sandbox**: Use Sandbox for agent execution environments and isolated tool calls, Orchestrate for durable workflow coordination
+- **Agentic + Sandbox**: Use Sandbox for agent execution environments and isolated tool calls, Orchestration for durable workflow coordination
 - **Persistent named sandboxes**: Create sandboxes with `name=` when state must survive between steps. Named sandboxes support suspend/resume, can be auto-suspended when idle, and auto-resume on the next sandbox-proxy request. See `references/sandbox_persistence.md` for the full state model.
 - **Document extraction**: Use DocumentAI with Pydantic schemas to extract structured data from PDFs/images
 - **LLM integration**: Use any LLM provider inside `@function()` — install deps via `Image`, pass keys via `secrets`
@@ -80,7 +80,7 @@ if __name__ == "__main__":
 
 Detailed API docs are in the `references/` directory:
 
-- `references/applications_sdk.md` — Orchestrate SDK: decorators, futures, map/reduce, images, context
+- `references/applications_sdk.md` — Orchestration SDK: decorators, futures, map/reduce, images, context
 - `references/sandbox_sdk.md` — Create sandboxes, connect, run commands, file ops, processes, networking, images
 - `references/sandbox_persistence.md` — Sandbox state: snapshots, suspend/resume, clone, ephemeral vs named, state machine
 - `references/documentai_sdk.md` — Parse, extract, classify, options

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to the TensorLake skill are documented here.
 
+## [2.4.0] — SDK 0.4.49 — 2026-04-22
+
+### Added
+- **sandbox_sdk.md** — new **Browser Access with noVNC** subsection under Computer Use: backend-tunnel + WebSocket bridge architecture for live human-facing desktop streams on VNC port `5901` (password `tensorlake`), with a `@novnc/novnc` browser client snippet and the hybrid pattern of `noVNC` for the live view + `sandbox.connect_desktop()` for programmatic actions. Sourced from the new upstream section in `sandboxes/computer-use.md`
+- **sandbox_sdk.md** — new **Running Docker Inside a Sandbox** subsection under Sandbox Images, cross-referencing the new upstream `sandboxes/docker.md` page (full install script lives there; `ubuntu-systemd` base image was already in the Base Images table)
+- **sandbox_sdk.md** — `sandboxes/concepts.md` (new upstream Sandbox SDK Reference page) and `sandboxes/docker.md` added to the source URL header
+- **sources.yaml** — four sources added to `sandbox_sdk.md`: `sandboxes/concepts.md`, `sandboxes/docker.md`, `sandboxes/environment-variables.md`, `sandboxes/quickstart.md`. The last two were already in the reference file's source header (added in v2.3.1) but had never been registered in `sources.yaml` — a drift-check bug from that release
+- **CLAUDE.md** — new rule: `SDK version:` and `Last verified:` must always bump together. Bumping the SDK version without also bumping the date creates a false record claiming verification against a newer SDK on an older date. Applies to PyPI releases, content edits, and `Source:` / `sources.yaml` URL changes
+
+### Changed
+- **SKILL.md** / **AGENTS.md** / **README.md** — renamed the product from "Orchestrate" to "Orchestration" to match the upstream docs terminology shift in `agent-skills.md` and the new `sandboxes/concepts.md`. Affects the "Two APIs" opening paragraph, Quick Start heading, Core Patterns bullet, reference-list title (`Orchestration SDK`), and the README description/tree comment. Lowercase verb uses of "orchestrate" ("orchestrate multi-step LLM pipelines") were left alone
+- All reference files + `sources.yaml` + README example — bumped `SDK version:` / `sdk_version:` to `tensorlake 0.4.49` (latest on PyPI) and `Last verified:` / `last_verified:` to `2026-04-22`
+
+### Fixed
+- **applications_sdk.md** / **sources.yaml** — removed dangling `applications/guides/autoscaling.md` entry (upstream page deleted in docs commit 3abea5f; content was consolidated into `applications/scaling-agents.md`, which was already tracked)
+
 ## [2.3.1] — SDK 0.4.46 — 2026-04-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Build production agent workflows with [Tensorlake's](https://tensorlake.ai).
 
 This skill helps coding agents use Tensorlake to build real agent systems with sandboxed execution and orchestration. It covers both the **Python** (`pip install tensorlake`) and **TypeScript** (`npm install tensorlake`) SDKs. It is designed for modern agent use cases like multi-agent applications, isolated code execution, long-running workflows, and tool-using agents that need a real workspace.
 
-Instead of treating Tensorlake as just another API, this skill teaches agents how to use Tensorlake as infrastructure: run tasks in isolated environments with the Sandbox SDK, coordinate durable workflows with the sandbox-native Orchestrate SDK, and compose reliable agent systems for production use.
+Instead of treating Tensorlake as just another API, this skill teaches agents how to use Tensorlake as infrastructure: run tasks in isolated environments with the Sandbox SDK, coordinate durable workflows with the sandbox-native Orchestration SDK, and compose reliable agent systems for production use.
 
 Use it when you want your coding agent to build:
 
@@ -19,7 +19,7 @@ Use it when you want your coding agent to build:
 It guides agents to:
 
 - use the **Sandbox SDK** for agent execution environments and isolated tool calls
-- use the **Orchestrate SDK** for sandbox-native durable workflow orchestration and multi-agent coordination
+- use the **Orchestration SDK** for sandbox-native durable workflow orchestration and multi-agent coordination
 - combine both SDKs to build production-style agent systems
 - choose Tensorlake patterns that are better than a single-agent or stateless approach
 
@@ -86,7 +86,7 @@ tensorlake-skills/
 │       ├── check_drift.py        # Compare fetched vs bundled
 │       └── sources.yaml          # Map: reference file → source URLs
 └── references/
-    ├── applications_sdk.md       # Orchestrate API reference
+    ├── applications_sdk.md       # Orchestration API reference
     ├── sandbox_sdk.md            # Sandbox API reference
     ├── sandbox_persistence.md    # Sandbox state: snapshots, suspend/resume, state machine
     ├── documentai_sdk.md         # DocumentAI API reference
@@ -152,8 +152,8 @@ Each reference file has a source header that tracks which doc pages it was built
 Source:
   - https://docs.tensorlake.ai/sandboxes/lifecycle.md
   - https://docs.tensorlake.ai/sandboxes/commands.md
-SDK version: tensorlake 0.4.42
-Last verified: 2026-04-08
+SDK version: tensorlake 0.4.49
+Last verified: 2026-04-22
 -->
 ```
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -12,12 +12,12 @@ description: >
   database, or API as the infrastructure layer.
 metadata:
   author: tensorlake
-  version: 2.3.1
+  version: 2.4.0
 ---
 
 # Tensorlake SDK
 
-Two APIs: **Sandbox** (stateful execution environments for agents and isolated tool calls, with suspend/resume, snapshots, and clone for persistence between tasks), **Orchestrate** (sandbox-native durable workflow orchestration for agents — imported as `tensorlake.applications`). Available in both **Python** (`pip install tensorlake`) and **TypeScript** (`npm install tensorlake`). Use standalone or as infrastructure alongside any LLM, agent framework, database, or API.
+Two APIs: **Sandbox** (stateful execution environments for agents and isolated tool calls, with suspend/resume, snapshots, and clone for persistence between tasks), **Orchestration** (sandbox-native durable workflow orchestration for agents — imported as `tensorlake.applications`). Available in both **Python** (`pip install tensorlake`) and **TypeScript** (`npm install tensorlake`). Use standalone or as infrastructure alongside any LLM, agent framework, database, or API.
 
 **For documentation questions**: Read the relevant reference file below to answer. If the bundled references don't cover it, direct the user to the Tensorlake docs site.
 **For building**: Use the Quick Start and Core Patterns below, plus reference files for API details.
@@ -33,7 +33,7 @@ Both SDKs ship with `tl` and `tensorlake` CLI tools. The skill itself declares n
 
 Do **not** ask the user to paste any key into the conversation, include keys in generated code, or print them in terminal output.
 
-## Quick Start — Orchestrate Workflow
+## Quick Start — Orchestration Workflow
 
 ```python
 from tensorlake.applications import (
@@ -73,7 +73,7 @@ if __name__ == "__main__":
 ## Core Patterns
 
 - **DAG composition**: Chain functions via `.future()`, `.map()`, `.reduce()` to form parallel pipelines
-- **Agentic + Sandbox**: Use Sandbox for agent execution environments and isolated tool calls, Orchestrate for durable workflow coordination
+- **Agentic + Sandbox**: Use Sandbox for agent execution environments and isolated tool calls, Orchestration for durable workflow coordination
 - **Persistent named sandboxes**: Create sandboxes with `name=` when state must survive between steps. Named sandboxes support suspend/resume, can be auto-suspended when idle, and auto-resume on the next sandbox-proxy request. See [references/sandbox_persistence.md](references/sandbox_persistence.md) for the full state model.
 - **Document extraction**: Use DocumentAI with Pydantic schemas to extract structured data from PDFs/images
 - **LLM integration**: Use any LLM provider inside `@function()` — install deps via `Image`, pass keys via `secrets`
@@ -96,7 +96,7 @@ For integration examples (LangChain, OpenAI, Anthropic, multi-agent orchestratio
 
 Bundled references (use when building with Tensorlake):
 
-- **Orchestrate SDK** (decorators, futures, map/reduce, images, context): See [references/applications_sdk.md](references/applications_sdk.md)
+- **Orchestration SDK** (decorators, futures, map/reduce, images, context): See [references/applications_sdk.md](references/applications_sdk.md)
 - **Sandbox SDK** (create, connect, run commands, file ops, processes, networking, images): See [references/sandbox_sdk.md](references/sandbox_sdk.md)
 - **Sandbox Persistence** (snapshots, suspend/resume, clone, ephemeral vs named, state machine): See [references/sandbox_persistence.md](references/sandbox_persistence.md)
 - **DocumentAI SDK** (parse, extract, classify, options): See [references/documentai_sdk.md](references/documentai_sdk.md)

--- a/references/applications_sdk.md
+++ b/references/applications_sdk.md
@@ -23,9 +23,8 @@ Source:
   - https://docs.tensorlake.ai/applications/sandboxes.md
   - https://docs.tensorlake.ai/applications/guides/streaming-progress.md
   - https://docs.tensorlake.ai/applications/guides/logging.md
-  - https://docs.tensorlake.ai/applications/guides/autoscaling.md
-SDK version: tensorlake 0.4.42
-Last verified: 2026-04-08
+SDK version: tensorlake 0.4.49
+Last verified: 2026-04-22
 -->
 
 # TensorLake Applications SDK Reference

--- a/references/documentai_sdk.md
+++ b/references/documentai_sdk.md
@@ -19,8 +19,8 @@ Source:
   - https://docs.tensorlake.ai/document-ingestion/datasets/data.md
   - https://docs.tensorlake.ai/document-ingestion/file-management/overview.md
   - https://docs.tensorlake.ai/document-ingestion/parsing/on-prem.md
-SDK version: tensorlake 0.4.39
-Last verified: 2026-04-08
+SDK version: tensorlake 0.4.49
+Last verified: 2026-04-22
 -->
 
 # TensorLake DocumentAI SDK Reference

--- a/references/integrations.md
+++ b/references/integrations.md
@@ -6,8 +6,8 @@ Source:
   - https://docs.tensorlake.ai/integrations/qdrant.md
   - https://docs.tensorlake.ai/integrations/databricks.md
   - https://docs.tensorlake.ai/integrations/motherduck.md
-SDK version: tensorlake 0.4.39
-Last verified: 2026-04-07
+SDK version: tensorlake 0.4.49
+Last verified: 2026-04-22
 -->
 
 # TensorLake Integration Patterns

--- a/references/platform.md
+++ b/references/platform.md
@@ -14,8 +14,8 @@ Source:
   - https://docs.tensorlake.ai/platform/playground/sample-documents.md
   - https://docs.tensorlake.ai/platform/security.md
   - https://docs.tensorlake.ai/platform/sso.md
-SDK version: tensorlake 0.4.42
-Last verified: 2026-04-08
+SDK version: tensorlake 0.4.49
+Last verified: 2026-04-22
 -->
 
 # TensorLake Platform Reference

--- a/references/sandbox_advanced.md
+++ b/references/sandbox_advanced.md
@@ -8,8 +8,8 @@ Source:
   - https://docs.tensorlake.ai/sandboxes/agentic-rl-reproducible-env.md
   - https://docs.tensorlake.ai/sandboxes/agentic-swarm-intelligence.md
   - https://docs.tensorlake.ai/sandboxes/gspo-agentic-rl.md
-SDK version: tensorlake 0.4.42
-Last verified: 2026-04-08
+SDK version: tensorlake 0.4.49
+Last verified: 2026-04-22
 -->
 
 # TensorLake Sandbox Advanced Patterns

--- a/references/sandbox_persistence.md
+++ b/references/sandbox_persistence.md
@@ -2,8 +2,8 @@
 Source:
   - https://docs.tensorlake.ai/sandboxes/lifecycle.md
   - https://docs.tensorlake.ai/sandboxes/snapshots.md
-SDK version: tensorlake 0.4.46
-Last verified: 2026-04-16
+SDK version: tensorlake 0.4.49
+Last verified: 2026-04-22
 -->
 
 # TensorLake Sandbox Persistence

--- a/references/sandbox_sdk.md
+++ b/references/sandbox_sdk.md
@@ -2,6 +2,7 @@
 Source:
   - https://docs.tensorlake.ai/sandboxes/introduction.md
   - https://docs.tensorlake.ai/sandboxes/quickstart.md
+  - https://docs.tensorlake.ai/sandboxes/concepts.md
   - https://docs.tensorlake.ai/sandboxes/commands.md
   - https://docs.tensorlake.ai/sandboxes/file-operations.md
   - https://docs.tensorlake.ai/sandboxes/processes.md
@@ -10,8 +11,9 @@ Source:
   - https://docs.tensorlake.ai/sandboxes/images.md
   - https://docs.tensorlake.ai/sandboxes/pty-sessions.md
   - https://docs.tensorlake.ai/sandboxes/computer-use.md
-SDK version: tensorlake 0.4.46
-Last verified: 2026-04-16
+  - https://docs.tensorlake.ai/sandboxes/docker.md
+SDK version: tensorlake 0.4.49
+Last verified: 2026-04-22
 -->
 
 # TensorLake Sandbox SDK Reference
@@ -497,6 +499,41 @@ with client.connect(sandbox_id) as sandbox:
 | `key_down()` | Key press (held) |
 | `key_up()` | Key release |
 
+### Browser Access with noVNC
+
+For a live human-facing desktop stream (instead of polling `screenshot()`), bridge the sandbox's VNC port to the browser with [`noVNC`](https://novnc.com/info.html). Recommended architecture:
+
+1. Keep `TENSORLAKE_API_KEY` on the backend.
+2. Backend opens a TCP tunnel to the sandbox's VNC port `5901`.
+3. Bridge that tunnel to a browser WebSocket endpoint (e.g. `/vnc/<session-id>`).
+4. Point `noVNC` at your backend WebSocket; authenticate with desktop password `tensorlake`.
+
+Sandbox proxy auth stays server-side — you do **not** need to expose port `5901` publicly. For hybrid agent + human sessions, use `noVNC` for the live view and `sandbox.connect_desktop()` / `sandbox.connectDesktop()` for programmatic actions on the backend.
+
+**Browser client:**
+
+```bash
+npm install @novnc/novnc
+```
+
+```ts
+import RFB from "@novnc/novnc/lib/rfb";
+
+const host = document.getElementById("desktop") as HTMLDivElement;
+const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+const url = `${protocol}//${window.location.host}/vnc`;
+
+const rfb = new RFB(host, url, {
+  credentials: { password: "tensorlake" },
+  shared: true,
+});
+rfb.scaleViewport = true;
+```
+
+```html
+<div id="desktop" style="width: 1200px; height: 800px; background: black;"></div>
+```
+
 ### Notes
 
 - Default VNC password for managed `ubuntu-vnc` image: `"tensorlake"`
@@ -590,6 +627,10 @@ const sandbox = await client.createAndConnect({
 tl sbx image create image.py --name data-tools-image
 tl sbx new --image data-tools-image
 ```
+
+### Running Docker Inside a Sandbox
+
+Docker requires systemd, so launch with the `tensorlake/ubuntu-systemd` base image and install Docker from the official Ubuntu repository inside the sandbox. See [sandboxes/docker.md](https://docs.tensorlake.ai/sandboxes/docker.md) for the full install script and a `docker run hello-world` verification step.
 
 ## Networking
 

--- a/references/troubleshooting.md
+++ b/references/troubleshooting.md
@@ -4,8 +4,8 @@ Source:
   - https://docs.tensorlake.ai/applications/production/troubleshooting.md
   - https://docs.tensorlake.ai/document-ingestion/production/integration.md
   - https://docs.tensorlake.ai/document-ingestion/production/benchmarks.md
-SDK version: tensorlake 0.4.39
-Last verified: 2026-04-07
+SDK version: tensorlake 0.4.49
+Last verified: 2026-04-22
 -->
 
 # TensorLake Troubleshooting & Production Guide


### PR DESCRIPTION
Sync the skill with upstream docs published since v2.3.1:

- Track new pages: sandboxes/concepts.md (comprehensive SDK reference) and sandboxes/docker.md (Docker-in-sandbox via ubuntu-systemd). Also register environment-variables.md and quickstart.md in sources.yaml — they were added to the sandbox_sdk.md header in v2.3.1 but never made it into the drift-check registry.
- Add noVNC browser-bridge subsection under Computer Use, mirroring the new upstream section in sandboxes/computer-use.md.
- Add a short Docker-in-sandbox cross-reference under Sandbox Images.
- Rename "Orchestrate" → "Orchestration" (product name) in SKILL.md, AGENTS.md, and README.md to match the terminology shift in agent-skills.md and sandboxes/concepts.md. Lowercase verb uses are left alone.
- Drop dangling applications/guides/autoscaling.md source (deleted upstream in docs commit 3abea5f; consolidated into scaling-agents.md, which was already tracked).
- Bump SDK version to tensorlake 0.4.49 and Last verified to 2026-04-22 across all reference files, sources.yaml, and the README example header.