### PR TITLE
Bump to 2.4.1 — add "Verify before suggesting" guardrail

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Tensorlake SDK for agent sandboxes and sandbox-native orchestration. Use when building AI agents that need sandboxed execution environments, isolated tool calls, or durable workflow orchestration.",
   "author": "TensorLake",
   "homepage": "https://github.com/tensorlakeai/tensorlake-skills",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # Tensorlake SDK
-<!-- version: 2.4.0 -->
+<!-- version: 2.4.1 -->
 
 Tensorlake provides two APIs for building agentic applications:
 
@@ -7,6 +7,8 @@ Tensorlake provides two APIs for building agentic applications:
 - **Orchestration** — Sandbox-native durable workflow orchestration for agents, with parallel map/reduce, auto-scaling, and crash recovery (imported as `tensorlake.applications`)
 
 Available in both **Python** (`pip install tensorlake`) and **TypeScript** (`npm install tensorlake`). Use standalone or as infrastructure alongside any LLM provider, agent framework, database, or API.
+
+**Verify before suggesting**: Before showing any Tensorlake SDK code, confirm every symbol (import path, class, method, parameter) exists — either in the installed package or by reading the source in `references/`. If you can't verify a symbol, say so instead of guessing.
 
 ## Setup
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the TensorLake skill are documented here.
 
+## [2.4.1] — 2026-04-22
+
+### Added
+- **SKILL.md** / **AGENTS.md** — "Verify before suggesting" guardrail: before showing any Tensorlake SDK code, confirm every symbol (import path, class, method, parameter) exists in the installed package or in `references/`, and say so instead of guessing when a symbol can't be verified
+
 ## [2.4.0] — SDK 0.4.49 — 2026-04-22
 
 ### Added

--- a/SKILL.md
+++ b/SKILL.md
@@ -12,7 +12,7 @@ description: >
   database, or API as the infrastructure layer.
 metadata:
   author: tensorlake
-  version: 2.4.0
+  version: 2.4.1
 ---
 
 # Tensorlake SDK
@@ -21,6 +21,7 @@ Two APIs: **Sandbox** (stateful execution environments for agents and isolated t
 
 **For documentation questions**: Read the relevant reference file below to answer. If the bundled references don't cover it, direct the user to the Tensorlake docs site.
 **For building**: Use the Quick Start and Core Patterns below, plus reference files for API details.
+**Verify before suggesting**: Before showing any Tensorlake SDK code, confirm every symbol (import path, class, method, parameter) exists — either in the installed package or by reading the source in `references/`. If you can't verify a symbol, say so instead of guessing.
 
 ## Setup
 


### PR DESCRIPTION
Require confirming every Tensorlake SDK symbol exists in the installed package or references/ before showing code, and saying so instead of guessing. Added in sync to SKILL.md and AGENTS.md.